### PR TITLE
Функция вывода полного адреса с возможностью использования в шаблонах

### DIFF
--- a/fias/models/addrobj.py
+++ b/fias/models/addrobj.py
@@ -78,7 +78,8 @@ class AddrObj(Common):
     def __unicode__(self):
         return self.get_natural_name()
 
-
+    def full_address(self):
+	return self.full_name(5)
 
 
 if 'mysql' in settings.DATABASES[FIAS_DATABASE_ALIAS]['ENGINE']:


### PR DESCRIPTION
Теперь в шаблоне можно получить полный адрес {{model.location.full_address}}, чтобы частично закрыть https://github.com/Yuego/django-fias/issues/5
