### PR TITLE
Django 1.8 compability

### DIFF
--- a/fias/widgets.py
+++ b/fias/widgets.py
@@ -5,10 +5,14 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language
+from django.utils.translation import get_language, force_text
 
-from django_select2.util import convert_to_js_str
 from django_select2.widgets import get_select2_css_libs, get_select2_heavy_js_libs, HeavySelect2Widget
+
+
+def convert_to_js_str(val):
+    val = force_text(val).replace('\'', '\\\'')
+    return u"'%s'" % val
 
 
 def get_js_libs():

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,10 @@ from fias.version import __version__
 extra_requirements = []
 if PY3:
     extra_requirements = [
-        'django_select2-Py3>=1.0.0',
         'suds-jurko>=0.6',
     ]
 else:
     extra_requirements = [
-        'django_select2>=4.2.2',
         'suds>=0.4',
     ]
 
@@ -33,6 +31,7 @@ setup(
     license='MIT license',
     install_requires=[
         'Django>=1.4',
+        'django_select2',
         'django-extensions>=1.0.0',
         'rarfile',
         'six',


### PR DESCRIPTION
django-select2 v4.3.1 теперь совместим с django 1.8 и python 3.
https://github.com/applegrew/django-select2 
Для работы django-fias совместно с django 1.8 необходимо обновить пакет django-select2