### PR TITLE
Исправлена версия django_select. Unrar tool не всегда = unrar

### DIFF
--- a/fias/importer/archive.py
+++ b/fias/importer/archive.py
@@ -9,6 +9,7 @@ from fias.importer.table import Table
 from fias.models import Status, Version
 from lxml.etree import XMLSyntaxError
 import rarfile
+rarfile.UNRAR_TOOL = 'unrar'
 try:
     from urllib import urlretrieve
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 django>=1.5
-django_select2>=3.2.0
+django_select2==4.3.2
 rarfile
 six
 lxml
 unrar
-suds

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license='MIT license',
     install_requires=[
         'django>=1.5',
-        'django_select2',
+        'django_select2==4.3.2',
         'rarfile',
         'six',
         'lxml',


### PR DESCRIPTION
 Выкидывает при установке. Текущая версия django_select2 5.4.2, где api полностью переписан по сравнению с версией 4, используемой в django-fias. Поставлен одназначный используемый вариант для unrar, т.к. сам по себе unrar не всегда установлени и при этом вылезает совершенно неясная ошибка, свидетельствующая о том, что файлы фиас не удалось открыть, дебажить эту ошибку непросто.