### PR TITLE
Repair progress error

### DIFF
--- a/fias/version.py
+++ b/fias/version.py
@@ -3,6 +3,6 @@ from __future__ import unicode_literals, absolute_import
 
 # fias version info
 
-VERSION = (1, 2, 4)
+VERSION = (1, 2, 5)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ lxml
 unrar
 zeep>=0.17.0
 dbfread>=2.0.0
-progress
+progress<1.5
 mysqlclient != 1.3.8


### PR DESCRIPTION

При установке библиотеки progress версии 1.5 возникает ошибка при импорте from progress.helpers import WritelnMixin